### PR TITLE
bug fix: keep mocha-jsdom in version 1.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chai-spies": "^0.7.1",
     "jsdom": "^8.5.0",
     "mocha": "^2.4.5",
-    "mocha-jsdom": "^1.1.0",
+    "mocha-jsdom": "~1.1.0",
     "mocha-multi": "^0.9.0"
   }
 }


### PR DESCRIPTION
Fix for #23, #24, #26 

With the previous specified version in the package json `^1.1.0`, this updates to a higher version which appear to have the breaking change mentioned in the issues above. I changed it to `~1.1.0` so that it stays at version 1.1.x